### PR TITLE
Componentwise error output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,11 +3,14 @@ Language:        Cpp
 BasedOnStyle:    Google
 
 AccessModifierOffset: -4
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
 BreakBeforeBraces: Allman
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: true
 IndentWidth:     4
+PointerAlignment: Left
+Standard:        C++11
 TabWidth:        4
 UseTab:          Never
-ExperimentalAutoDetectBinPacking: true
-Standard:        C++11

--- a/vtkdiff.cpp
+++ b/vtkdiff.cpp
@@ -7,8 +7,8 @@
  */
 
 #include <algorithm>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <ios>
 #include <sstream>
@@ -17,11 +17,11 @@
 
 #include <tclap/CmdLine.h>
 
+#include <vtkCellData.h>
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkPointData.h>
-#include <vtkCellData.h>
 #include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
 #include <vtkXMLUnstructuredGridReader.h>
@@ -30,7 +30,7 @@ template <typename T>
 auto float_to_string(T const& v) -> std::string
 {
     static_assert(std::is_floating_point<T>::value,
-        "float_to_string requires a floating point input type.");
+                  "float_to_string requires a floating point input type.");
 
     std::stringstream double_eps_sstream;
     double_eps_sstream << std::scientific << std::setprecision(16) << v;
@@ -88,12 +88,7 @@ auto parseCommandLine(int argc, char* argv[]) -> Args
     cmd.add(vtk_input_b_arg);
 
     TCLAP::ValueArg<std::string> data_array_a_arg(
-        "a",
-        "first",
-        "First data array name for comparison",
-        true,
-        "",
-        "NAME");
+        "a", "first", "First data array name for comparison", true, "", "NAME");
     cmd.add(data_array_a_arg);
 
     TCLAP::ValueArg<std::string> data_array_b_arg(
@@ -105,25 +100,21 @@ auto parseCommandLine(int argc, char* argv[]) -> Args
         "NAME");
     cmd.add(data_array_b_arg);
 
-    TCLAP::SwitchArg quiet_arg(
-        "q",
-        "quiet",
-        "Suppress all but error output.");
+    TCLAP::SwitchArg quiet_arg("q", "quiet", "Suppress all but error output.");
     cmd.add(quiet_arg);
 
-    TCLAP::SwitchArg verbose_arg(
-        "v",
-        "verbose",
-        "Also print which values differ.");
+    TCLAP::SwitchArg verbose_arg("v", "verbose",
+                                 "Also print which values differ.");
     cmd.add(verbose_arg);
 
-    auto const double_eps_string = float_to_string(
-        std::numeric_limits<double>::epsilon());
+    auto const double_eps_string =
+        float_to_string(std::numeric_limits<double>::epsilon());
 
     TCLAP::ValueArg<double> abs_err_thr_arg(
         "",
         "abs",
-        "Tolerance for the absolute error in the maximum norm (" + double_eps_string + ")",
+        "Tolerance for the absolute error in the maximum norm (" +
+            double_eps_string + ")",
         false,
         std::numeric_limits<double>::epsilon(),
         "FLOAT");
@@ -132,7 +123,8 @@ auto parseCommandLine(int argc, char* argv[]) -> Args
     TCLAP::ValueArg<double> rel_err_thr_arg(
         "",
         "rel",
-        "Tolerance for the componentwise relative error (" + double_eps_string + ")",
+        "Tolerance for the componentwise relative error (" + double_eps_string +
+            ")",
         false,
         std::numeric_limits<double>::epsilon(),
         "FLOAT");
@@ -140,16 +132,10 @@ auto parseCommandLine(int argc, char* argv[]) -> Args
 
     cmd.parse(argc, argv);
 
-    return Args
-        { quiet_arg.getValue()
-        , verbose_arg.getValue()
-        , abs_err_thr_arg.getValue()
-        , rel_err_thr_arg.getValue()
-        , vtk_input_a_arg.getValue()
-        , vtk_input_b_arg.getValue()
-        , data_array_a_arg.getValue()
-        , data_array_b_arg.getValue()
-        };
+    return Args{quiet_arg.getValue(),        verbose_arg.getValue(),
+                abs_err_thr_arg.getValue(),  rel_err_thr_arg.getValue(),
+                vtk_input_a_arg.getValue(),  vtk_input_b_arg.getValue(),
+                data_array_a_arg.getValue(), data_array_b_arg.getValue()};
 }
 
 template <typename T>
@@ -170,13 +156,12 @@ public:
     }
 };
 
-template<typename T>
+template <typename T>
 std::tuple<bool, vtkSmartPointer<vtkDataArray>, vtkSmartPointer<vtkDataArray>>
-readDataArraysFromFile(
-        std::string const& file_a_name,
-        std::string const& file_b_name,
-        std::string const& data_array_a_name,
-        std::string const& data_array_b_name)
+readDataArraysFromFile(std::string const& file_a_name,
+                       std::string const& file_b_name,
+                       std::string const& data_array_a_name,
+                       std::string const& data_array_b_name)
 {
     vtkSmartPointer<ErrorCallback<T>> errorCallback =
         vtkSmartPointer<ErrorCallback<T>>::New();
@@ -197,8 +182,8 @@ readDataArraysFromFile(
     else
     {
         std::cerr << "Error: Scalars data array "
-            << "\'" << data_array_a_name.c_str() << "\'"
-            << " neither found in point data nor in cell data.\n";
+                  << "\'" << data_array_a_name.c_str() << "\'"
+                  << " neither found in point data nor in cell data.\n";
         return std::make_tuple(false, nullptr, nullptr);
     }
 
@@ -217,14 +202,16 @@ readDataArraysFromFile(
     if (!a)
     {
         std::cerr << "Error: Scalars data array "
-            << "\'" << data_array_a_name.c_str() << "\'"
-            << " could not be read.\n";
+                  << "\'" << data_array_a_name.c_str() << "\'"
+                  << " could not be read.\n";
         return std::make_tuple(false, nullptr, nullptr);
     }
 
     vtkSmartPointer<vtkDataArray> b;
-    if (file_b_name.empty()) {
-        if (data_array_a_name == data_array_b_name) {
+    if (file_b_name.empty())
+    {
+        if (data_array_a_name == data_array_b_name)
+        {
             std::cerr << "Error: You are trying to compare data array `"
                       << data_array_a_name << "' from file `" << file_a_name
                       << "' to itself. Aborting.\n";
@@ -238,7 +225,9 @@ readDataArraysFromFile(
             b = vtkSmartPointer<vtkDataArray>{
                 reader_a->GetOutput()->GetCellData()->GetScalars(
                     data_array_b_name.c_str())};
-    } else {
+    }
+    else
+    {
         vtkSmartPointer<T> reader_b = vtkSmartPointer<T>::New();
         reader_b->AddObserver(vtkCommand::ErrorEvent, errorCallback);
         reader_b->SetFileName(file_b_name.c_str());
@@ -256,8 +245,8 @@ readDataArraysFromFile(
     if (!b)
     {
         std::cerr << "Error: Scalars data array "
-            << "\'" << data_array_b_name.c_str() << "\'"
-            << " not found.\n";
+                  << "\'" << data_array_b_name.c_str() << "\'"
+                  << " not found.\n";
         return std::make_tuple(false, nullptr, nullptr);
     }
 
@@ -297,9 +286,9 @@ int main(int argc, char* argv[])
 
     if (!args.quiet)
         std::cout << "Comparing data array `" << args.data_array_a
-            << "' from file `" << args.vtk_input_a
-            << "' to data array `" << args.data_array_b
-            << "' from file `" << args.vtk_input_b << "'.\n";
+                  << "' from file `" << args.vtk_input_a << "' to data array `"
+                  << args.data_array_b << "' from file `" << args.vtk_input_b
+                  << "'.\n";
 
     // Check similarity of the data arrays.
 
@@ -307,14 +296,14 @@ int main(int argc, char* argv[])
     if (!a->IsNumeric())
     {
         std::cerr << "Data in data array a is not numeric:\n"
-            << "data type is " << a->GetDataTypeAsString() << "\n";
+                  << "data type is " << a->GetDataTypeAsString() << "\n";
 
         return EXIT_FAILURE;
     }
     if (!b->IsNumeric())
     {
         std::cerr << "Data in data array b is not numeric.\n"
-            << "data type is " << b->GetDataTypeAsString() << "\n";
+                  << "data type is " << b->GetDataTypeAsString() << "\n";
         return EXIT_FAILURE;
     }
 
@@ -323,8 +312,8 @@ int main(int argc, char* argv[])
     if (num_tuples != b->GetNumberOfTuples())
     {
         std::cerr << "Number of tuples differ:\n"
-            << num_tuples << " in data array a and "
-            << b->GetNumberOfTuples() << " in data array b\n";
+                  << num_tuples << " in data array a and "
+                  << b->GetNumberOfTuples() << " in data array b\n";
         return EXIT_FAILURE;
     }
 
@@ -333,8 +322,8 @@ int main(int argc, char* argv[])
     if (num_components != b->GetNumberOfComponents())
     {
         std::cerr << "Number of components differ:\n"
-            << num_components << " in data array a and "
-            << b->GetNumberOfComponents() << " in data array b\n";
+                  << num_components << " in data array a and "
+                  << b->GetNumberOfComponents() << " in data array b\n";
         return EXIT_FAILURE;
     }
 
@@ -352,36 +341,46 @@ int main(int argc, char* argv[])
 
     for (auto tuple_idx = 0; tuple_idx < num_tuples; ++tuple_idx)
     {
-        for (auto component_idx = 0; component_idx < num_components; ++component_idx)
+        for (auto component_idx = 0; component_idx < num_components;
+             ++component_idx)
         {
             auto const a_comp = a->GetComponent(tuple_idx, component_idx);
             auto const b_comp = b->GetComponent(tuple_idx, component_idx);
             auto const abs_err = std::abs(a_comp - b_comp);
 
-            abs_err_norm_l1  += abs_err;
-            abs_err_norm_2_2 += abs_err*abs_err;
-            abs_err_norm_max  = std::max(abs_err_norm_max, abs_err);
+            abs_err_norm_l1 += abs_err;
+            abs_err_norm_2_2 += abs_err * abs_err;
+            abs_err_norm_max = std::max(abs_err_norm_max, abs_err);
 
             // relative error and its norms:
             double rel_err;
 
-            if (abs_err == 0.0) {
+            if (abs_err == 0.0)
+            {
                 rel_err = 0.0;
-            } else if (a_comp == 0.0 || b_comp == 0.0) {
+            }
+            else if (a_comp == 0.0 || b_comp == 0.0)
+            {
                 rel_err = std::numeric_limits<double>::infinity();
-            } else {
-                rel_err = abs_err / std::min(std::abs(a_comp), std::abs(b_comp));
+            }
+            else
+            {
+                rel_err =
+                    abs_err / std::min(std::abs(a_comp), std::abs(b_comp));
             }
 
-            rel_err_norm_l1  += rel_err;
-            rel_err_norm_2_2 += rel_err*rel_err;
-            rel_err_norm_max  = std::max(rel_err_norm_max, rel_err);
+            rel_err_norm_l1 += rel_err;
+            rel_err_norm_2_2 += rel_err * rel_err;
+            rel_err_norm_max = std::max(rel_err_norm_max, rel_err);
 
-            if (abs_err > args.abs_err_thr && rel_err > args.rel_err_thr && args.verbose)
+            if (abs_err > args.abs_err_thr && rel_err > args.rel_err_thr &&
+                args.verbose)
             {
                 std::cout << std::setw(4) << tuple_idx
-                          << ": abs err = " << std::setw(digits10+7) << abs_err
-                          << ", rel err = " << std::setw(digits10+7) << rel_err << "\n";
+                          << ": abs err = " << std::setw(digits10 + 7)
+                          << abs_err
+                          << ", rel err = " << std::setw(digits10 + 7)
+                          << rel_err << "\n";
             }
         }
     }
@@ -389,17 +388,20 @@ int main(int argc, char* argv[])
     // Error information
     if (!args.quiet)
         std::cout << "Computed difference between data arrays:\n"
-            << "abs l1 norm      = " << abs_err_norm_l1 << "\n"
-            << "abs l2-norm^2    = " << abs_err_norm_2_2 << "\n"
-            << "abs l2-norm      = " << std::sqrt(abs_err_norm_2_2) << "\n"
-            << "abs maximum norm = " << abs_err_norm_max << "\n"
-            << "\n"
-            << "rel l1 norm      = " << rel_err_norm_l1 << "\n"
-            << "rel l2-norm^2    = " << rel_err_norm_2_2 << "\n"
-            << "rel l2-norm      = " << std::sqrt(rel_err_norm_2_2) << "\n"
-            << "rel maximum norm = " << rel_err_norm_max << "\n";
+                  << "abs l1 norm      = " << abs_err_norm_l1 << "\n"
+                  << "abs l2-norm^2    = " << abs_err_norm_2_2 << "\n"
+                  << "abs l2-norm      = " << std::sqrt(abs_err_norm_2_2)
+                  << "\n"
+                  << "abs maximum norm = " << abs_err_norm_max << "\n"
+                  << "\n"
+                  << "rel l1 norm      = " << rel_err_norm_l1 << "\n"
+                  << "rel l2-norm^2    = " << rel_err_norm_2_2 << "\n"
+                  << "rel l2-norm      = " << std::sqrt(rel_err_norm_2_2)
+                  << "\n"
+                  << "rel maximum norm = " << rel_err_norm_max << "\n";
 
-    if (abs_err_norm_max > args.abs_err_thr && rel_err_norm_max > args.rel_err_thr)
+    if (abs_err_norm_max > args.abs_err_thr &&
+        rel_err_norm_max > args.rel_err_thr)
     {
         if (!args.quiet)
             std::cout << "Absolute and relative error (maximum norm) are larger"


### PR DESCRIPTION
Changes scalar error output to componentwise.

```
Comparing data array `displacement' from file `/a.vtu' to data array `displacement' from file b.vtu'.
Computed difference between data arrays:
abs l1 norm      = [6.322677434779725e-18, 2.661801036746639e-18, 9.131453907998256e-17]
abs l2-norm^2    = [7.321818107260313e-38, 3.350506870278181e-38, 1.350350345812965e-35]
abs l2-norm      = [2.705885826722982e-19, 1.830438982943212e-19, 3.674711343511168e-18]
abs maximum norm = [2.032879073410321e-20, 1.355252715606881e-20, 3.553303213731790e-19]

rel l1 norm      = [2.462433521712641e-13, 4.334277140183466e-14, 2.707732549485776e-11]
rel l2-norm^2    = [1.794788506143333e-28, 9.963422523306233e-30, 1.115909733803852e-24]
rel maximum norm = [4.626155059082822e-15, 8.841632773359837e-16, 1.411717125844000e-13]
```

Computation of the maximum error does not change.

First commit is just formatting, no changes.